### PR TITLE
Cancel appointment

### DIFF
--- a/src/models/CoreAppointment.ts
+++ b/src/models/CoreAppointment.ts
@@ -1,7 +1,7 @@
 import mongoose, { Schema, Document } from 'mongoose'
 
 export interface ICoreAppointment extends Document {
-  status: 'upcoming' | 'open' | 'closed' | 'locked'
+  status: 'upcoming' | 'open' | 'closed' | 'locked' | 'cancelled'
   appointmentType: 'A' | 'V'
   id: string
   date: Date
@@ -9,7 +9,7 @@ export interface ICoreAppointment extends Document {
 
 const CoreAppointmentSchema: Schema = new Schema(
   {
-    status: { type: String, enum: ['upcoming', 'open', 'closed', 'locked'], required: true },
+    status: { type: String, enum: ['upcoming', 'open', 'closed', 'locked','cancelled'], required: true },
     appointmentType: { type: String, enum: ['A', 'V'], required: true },
     date: { type: Date, required: true },
     id: { type: String, required: true },

--- a/src/server.ts
+++ b/src/server.ts
@@ -572,7 +572,7 @@ app.post('/profile/doctor/appointments/cancel/:id', keycloak.protect('realm:doct
     console.log("status from core-health: ", resp.status)
     //Success of request == 201 because it is a POST method
     if (resp.status == 201) {
-      await CoreAppointment.deleteOne({ id: appId })
+      await CoreAppointment.updateOne({ id: appId },{status:'cancelled'})
       res.sendStatus(200)
     }else{
       res.sendStatus(resp.status)

--- a/src/server.ts
+++ b/src/server.ts
@@ -407,7 +407,7 @@ app.get('/profile/doctor/appointments/:id/encounter', keycloak.protect('realm:do
 // GET /profile/doctor/appointments/:id - Read doctor appointment
 // POST /profile/doctor/appointments/:id - Update doctor appointment
 // DELETE /profile/doctor/appointments/:id - Delete doctor appointment
-//
+// POST /profile/doctor/appointments/cancel/:id - Cancel appointment by doctor 
 
 app.get(
   '/profile/doctor/appointments',
@@ -563,6 +563,26 @@ app.delete('/profile/doctor/appointments/:id', keycloak.protect('realm:doctor'),
   }
 })
 
+app.post('/profile/doctor/appointments/cancel/:id', keycloak.protect('realm:doctor'), async (req, res) => {
+  try {
+    let appId = req.params.id
+    const resp =  await axios.post(`/profile/doctor/appointments/cancel/${appId}`,{}, {
+      headers: { Authorization: `Bearer ${getAccessToken(req)}` },
+    })
+    console.log("status from core-health: ", resp.status)
+    //Success of request == 201 because it is a POST method
+    if (resp.status == 201) {
+      await CoreAppointment.deleteOne({ id: appId })
+      res.sendStatus(200)
+    }else{
+      res.sendStatus(resp.status)
+    }
+  } catch (err) {
+    res.send(err)
+    handleError(req, res, err)
+  }
+})
+
 //
 // PRESCRIPTIONS for PATIENTS:
 // Protected Routes for managing profile prescriptions
@@ -692,6 +712,26 @@ app.post(
     }
   }
 )
+
+app.post('/profile/patient/appointments/cancel/:id', keycloak.protect('realm:patient'), async (req, res) => {
+  try {
+    let appId = req.params.id
+    const resp =  await axios.post(`/profile/patient/appointments/cancel/${appId}`,{}, {
+      headers: { Authorization: `Bearer ${getAccessToken(req)}` },
+    })
+    console.log("status from core-health: ", resp.status)
+    //Success of request == 201 because it is a POST method
+    if (resp.status == 201) {
+      await CoreAppointment.updateOne({ id: appId },{status:'cancelled'})
+      res.sendStatus(200)
+    }else{
+      res.sendStatus(resp.status)
+    }
+  } catch (err) {
+    res.send(err)
+    handleError(req, res, err)
+  }
+})
 
 //
 // Doctor

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -27,7 +27,7 @@ export const calculateAvailability = async (doctorId: string, start: Date, end: 
     const startFHIR = new Date(start)
     startFHIR.setHours(startFHIR.getHours() - 1)
     const resp = await axios.get<iHub.Appointment[]>(
-      `/appointments?doctors=${doctorId}&start=${startFHIR.toISOString()}&end=${end.toISOString()}`
+      `/appointments?doctors=${doctorId}&start=${startFHIR.toISOString()}&end=${end.toISOString()}&status=Booked`
     )
 
     // Get the doctors other appointments


### PR DESCRIPTION
Services for patient and doctors to cancel appointments.
Update mongo schema for CoreAppointments to include the status == cancelled
Update filter params in list appointment inside calculate doctor availability to take into account only non-cancelled appointmetns in the blocked slots.