### PR TITLE
Fix appointment time slots

### DIFF
--- a/src/models/Appointment.ts
+++ b/src/models/Appointment.ts
@@ -8,7 +8,7 @@ export interface IAppointment extends Document {
   name: string
   start: Date
   end: Date
-  appointmentType: "A" | "V"
+  appointmentType: "A" | "V" | "E"
   description: string
   doctorId: string
   type: 'PrivateEvent'
@@ -17,7 +17,8 @@ export interface IAppointment extends Document {
 const AppointmentSchema: Schema = new Schema(
   {
     name: { type: String, required: true },
-    appointmentType: { type: String, enum: ['A', 'V'], required: true },
+    //A:Ambulatory V:Virtual E:Doctor's Events
+    appointmentType: { type: String, enum: ['A', 'V', "E"], required: true },
     start: { type: Date, required: true },
     end: { type: Date, required: true },
     description: String,

--- a/src/server.ts
+++ b/src/server.ts
@@ -603,15 +603,13 @@ app.post(
   body('name').isString(),
   body(['start', 'end']).isISO8601(),
   body('description').isString().optional(),
-  body('appointmentType').isString(),
   async (req, res) => {
     if (!validate(req, res)) return
     if (!req.userId) return res.sendStatus(500)
 
     const { type, name, start, end, description,appointmentType } = req.body
-
     try {
-      const appointment = await Appointment.create({appointmentType, type, name, start, end, description, doctorId: req.userId })
+      const appointment = await Appointment.create({appointmentType:"E", type, name, start, end, description, doctorId: req.userId})
       res.send(appointment)
     } catch (err) {
       handleError(req, res, err)


### PR DESCRIPTION
Now all the blocked intervals of the days are taken into account to calculate the open slots.
The type of appointment for doctor event is set automatically to "E".