### PR TITLE
fix: ArchiveAppointment mongoose connection buffer problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+#Intellij
+.idea

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "migrateDev": "ts-node --dir scripts migrate",
     "migrate": "node bin/scripts/migrate",
     "archiveAppointmentsDev": "ts-node --dir scripts archiveAppointments.ts",
-    "archiveAppointments": "node bin/scripts/archiveAppointments"
+    "archiveAppointments": "node dist/scripts/archiveAppointments"
   },
   "dependencies": {
     "@types/compression": "^1.7.0",

--- a/src/models/CoreAppointment.ts
+++ b/src/models/CoreAppointment.ts
@@ -7,7 +7,7 @@ export interface ICoreAppointment extends Document {
   date: Date
 }
 
-const CoreAppointmentSchema: Schema = new Schema(
+export const CoreAppointmentSchema: Schema = new Schema(
   {
     status: { type: String, enum: ['upcoming', 'open', 'closed', 'locked','cancelled'], required: true },
     appointmentType: { type: String, enum: ['A', 'V'], required: true },

--- a/src/scripts/archiveAppointments.ts
+++ b/src/scripts/archiveAppointments.ts
@@ -3,7 +3,7 @@ import 'dotenv/config'
 import mongoose from 'mongoose'
 import axios from 'axios'
 import express from 'express'
-import CoreAppointment from '../src/models/CoreAppointment'
+import {ICoreAppointment, CoreAppointmentSchema} from '../models/CoreAppointment'
 
 // This script updates the status of CoreAppointments Documents in MongoDB 
 // It is executed periodically by a crontab 
@@ -34,34 +34,37 @@ kcConfig)
 
 
 export const archiveAppointments = async () => {
-  await mongoose.connect(`${process.env.MONGODB_URI}`, {
+  let conn = await mongoose.createConnection(`${process.env.MONGODB_URI}`, {
     useNewUrlParser: true,
     useCreateIndex: true,
     useFindAndModify: false,
     useUnifiedTopology: true,
+    socketTimeoutMS:50000
   })
 
   const hoursAgo = new Date()
   hoursAgo.setHours(hoursAgo.getHours() - 2)
 
   try {
-    const res = await CoreAppointment.updateMany(
+    let coreAppointmentModel = conn.model<ICoreAppointment>('CoreAppointment', CoreAppointmentSchema) //access to model via the connection
+    const res = await coreAppointmentModel.updateMany(
       { date: { $lte: hoursAgo }, status: {$nin :["cancelled","locked"]} },
       { status: 'locked' }
     )
-    console.log('🏛 ✅ DAILY ARCHIVE ORDERS TASK RESULTS: ', res)
+    console.log('SCRIPT LOG: 🏛 ✅ DAILY ARCHIVE ORDERS TASK RESULTS: ', res)
   } catch (err) {
     console.log(err)
+  } finally {
+    await conn.close()
   }
-  mongoose.disconnect()
 
   const authentication =await keycloak.grantManager.obtainDirectly(process.env.BOLDO_ADMIN, process.env.BOLDO_PASS)
   const boldoToken = authentication.access_token.token
   const response = await axios.put(`/profile/admin/encounter/status`,{}, {
     headers: { Authorization: `Bearer ${boldoToken}` },
   })
-  console.log("Encounter status update: ",response.status)
-  
+  console.log("SCRIPT LOG: Core-health-mapper 🔥 -> Encounter status update: ", response.status + " " + response.statusText)
+
 }
 
 if (require.main === module) {

--- a/src/scripts/info.md
+++ b/src/scripts/info.md
@@ -1,0 +1,1 @@
+This directory contains scripts that are executed by endpoints defined in [server.ts](../server.ts)

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,8 @@ import {
   filterByAppointmentAvailability as filterByTypeOfAvailability
 } from './util/helpers'
 
+import { archiveAppointments } from './scripts/archiveAppointments'
+
 // We use axios for queries to the iHub Server
 axios.defaults.baseURL = process.env.IHUB_ADDRESS!
 
@@ -1592,6 +1594,19 @@ app.get('/specializations', async (req, res) => {
     handleError(req, res, err)
   }
 })
+
+//
+//ENDPOINT FOR ADMIN
+//this endpoint calls the archiveAppointments script.
+app.post('/profile/admin/archiveAppointments', async (req, res) => {
+  try {
+    const toReturn = await archiveAppointments()
+    res.send('Script run successfully 🔥')
+  } catch (err) {
+    handleError(req, res, err)
+  }
+})
+
 
 //
 //


### PR DESCRIPTION
+ A new connection with mongoose.createConnection() is necessary in order to not interfere with mongoose default connection used with models
+ This avoid buffering problems when executing both script call from endpoint, and the other regulars endpoints